### PR TITLE
Compile with corei7 instruction set, and enable the "fat" binaries

### DIFF
--- a/metaBuild.sh
+++ b/metaBuild.sh
@@ -9,7 +9,7 @@ if [ "$1" = "build" ]; then
   elif echo "$SYSTEM_NAME" | grep -q "MINGW64_NT"; then
     echo "Building for Windows"
     (cd $DIR && \
-    ./configure --enable-cxx --enable-gmpcompat --enable-shared --disable-static && \
+    ./configure --host=corei7-w64-mingw64 --enable-fat --enable-cxx --enable-gmpcompat --enable-shared --disable-static && \
     make)
   elif echo "$SYSTEM_NAME" | grep -q "MSYS"; then
     echo "ERROR: the MSYS shell is not supported. Please use the MinGW-w64 Win64 Shell instead."


### PR DESCRIPTION
@ahk was experiencing some issues related to 'illegal instruction' errors when running some builds of otherplan. After some experiments with compile flags, I determined that MPIR and geode were generating assembly instructions for our specific machines instead of choosing a common set.

This patch locks down the CPU architecture to corei7 to try and solve that, which is used in the qmake configuration for otherplan.
